### PR TITLE
Add support for Django Allauth

### DIFF
--- a/netbox/netbox/admin.py
+++ b/netbox/netbox/admin.py
@@ -2,6 +2,16 @@ from django.conf import settings
 from django.contrib.admin import AdminSite
 from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.auth.models import Group, User
+from django.contrib.sites.admin import SiteAdmin
+from django.contrib.sites.models import Site
+from allauth.socialaccount.admin import (
+    SocialApp,
+    SocialAppAdmin,
+    SocialAccount,
+    SocialAccountAdmin,
+    SocialToken,
+    SocialTokenAdmin,
+)
 
 
 class NetBoxAdminSite(AdminSite):
@@ -18,6 +28,12 @@ admin_site = NetBoxAdminSite(name='admin')
 # Register external models
 admin_site.register(Group, GroupAdmin)
 admin_site.register(User, UserAdmin)
+admin_site.register(Site, SiteAdmin)
+
+# Register allauth models
+admin_site.register(SocialApp, SocialAppAdmin)
+admin_site.register(SocialAccount, SocialAccountAdmin)
+admin_site.register(SocialToken, SocialTokenAdmin)
 
 # Modify the template to include an RQ link if django_rq is installed (see RQ_SHOW_ADMIN_LINK)
 if settings.WEBHOOKS_ENABLED:

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -160,9 +160,14 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
+    'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.github',
     'cacheops',
     'corsheaders',
     'debug_toolbar',
@@ -234,6 +239,8 @@ TEMPLATES = [
 # Authentication
 AUTHENTICATION_BACKENDS = [
     'utilities.auth_backends.ViewExemptModelBackend',
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
 ]
 
 # Internationalization
@@ -390,6 +397,19 @@ PROMETHEUS_EXPORT_MIGRATIONS = False
 FILTERS_NULL_CHOICE_LABEL = 'None'
 FILTERS_NULL_CHOICE_VALUE = 'null'
 
+
+#
+# Django Site
+#
+
+SITE_ID = 1
+
+#
+# Django Allauth
+#
+
+ACCOUNT_DEFAULT_HTTP_PROTOCOL='https'
+LOGIN_REDIRECT_URL = 'home'
 
 #
 # Django REST framework (API)

--- a/netbox/netbox/urls.py
+++ b/netbox/netbox/urls.py
@@ -31,6 +31,9 @@ _patterns = [
     path(r'login/', LoginView.as_view(), name='login'),
     path(r'logout/', LogoutView.as_view(), name='logout'),
 
+    # AllAuth
+    path(r'accounts/', include('allauth.urls')),
+
     # Apps
     path(r'circuits/', include('circuits.urls')),
     path(r'dcim/', include('dcim.urls')),

--- a/netbox/templates/extras/provider_list.html
+++ b/netbox/templates/extras/provider_list.html
@@ -1,0 +1,20 @@
+{% load socialaccount %}
+
+{% get_providers as socialaccount_providers %}
+
+{% for provider in socialaccount_providers %}
+    {% if provider.id == "openid" %}
+        {% for brand in provider.get_brands %}
+            <li>
+                <a title="{{brand.name}}" class="btn btn-block btn-social btn-md btn-{{ provider.id }} socialaccount_provider {{provider.id}} {{brand.id}}" href="{% provider_login_url provider.id openid=brand.openid_url process=process %}">
+                    <i class="fa fa-{{ provider.id }}"></i>Log in with {{ brand.name }}
+                </a>
+            </li>
+        {% endfor %}
+    {% endif %}
+    <li>
+        <a title="{{provider.name}}" class="btn btn-block btn-social btn-md btn-{{ provider.id }} socialaccount_provider {{provider.id}}" href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">
+            <i class="fa fa-{{ provider.id }}"></i>Log in with {{ provider.name }}
+        </a>
+    </li>
+{% endfor %}

--- a/netbox/templates/login.html
+++ b/netbox/templates/login.html
@@ -1,5 +1,7 @@
 {% extends '_base.html' %}
 {% load form_helpers %}
+{% load account socialaccount %}
+
 
 {% block content %}
 <div class="row" style="margin-top: {% if settings.BANNER_LOGIN %}100{% else %}150{% endif %}px;">
@@ -23,6 +25,14 @@
                     <strong>Log In</strong>
                 </div>
                 <div class="panel-body">
+                    {% get_providers as socialaccount_providers %}
+                    {% if socialaccount_providers %}
+                        <div class="socialaccount_ballot">
+                            <ul class="socialaccount_providers">
+                                {% include "extras/provider_list.html" with process="login" %}
+                            </ul>
+                        </div>
+                    {% endif %}
                     {% csrf_token %}
                     {% if 'next' in request.GET %}<input type="hidden" name="next" value="{{ request.GET.next }}" />{% endif %}
                     {% if 'next' in request.POST %}<input type="hidden" name="next" value="{{ request.POST.next }}" />{% endif %}

--- a/netbox/templates/users/_user.html
+++ b/netbox/templates/users/_user.html
@@ -23,8 +23,8 @@
             </li>
         </ul>
     </div>
-	<div class="col-sm-9 col-md-6">
+    <div class="col-sm-9 col-md-6">
         {% block usercontent %}{% endblock %}
-	</div>
+    </div>
 </div>
 {% endblock %}

--- a/netbox/utilities/middleware.py
+++ b/netbox/utilities/middleware.py
@@ -22,7 +22,7 @@ class LoginRequiredMiddleware(object):
             # Redirect unauthenticated requests to the login page. API requests are exempt from redirection as the API
             # performs its own authentication. Also metrics can be read without login.
             api_path = reverse('api-root')
-            if not request.path_info.startswith((api_path, '/metrics')) and request.path_info != settings.LOGIN_URL:
+            if not request.path_info.startswith((api_path, '/metrics', '/accounts')) and request.path_info != settings.LOGIN_URL:
                 return HttpResponseRedirect(
                     '{}?next={}'.format(
                         settings.LOGIN_URL,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django>=2.2,<2.3
+django-allauth==0.39.1
 django-cacheops==4.1
 django-cors-headers==3.0.2
 django-debug-toolbar==2.0


### PR DESCRIPTION
This adds Django Allauth, a plugin which supports a ton of OpenID and OAuth2 endpoints. For Vapor we wish to ditch standard login and skip ldap. This gives us Github, Google, and about 50 other potential auth endpoints.

This PR is WIP as there's a few things missing:

- [ ] Add/Remove social logins to a user / profile
- [ ] Tweak styling of login buttons
- [ ] Add support for removing standard login username / password