### PR TITLE
Pull in Serializers for Vapor overrides

### DIFF
--- a/netbox/vapor/api/serializers.py
+++ b/netbox/vapor/api/serializers.py
@@ -1,24 +1,112 @@
 from rest_framework import serializers
 from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
+from drf_yasg.utils import swagger_serializer_method
+from dcim.constants import CONNECTION_STATUS_CHOICES, IFACE_TYPE_CHOICES
 
 from extras.api.customfields import CustomFieldModelSerializer
 from dcim.api.nested_serializers import (
     NestedDeviceSerializer,
-    NestedInterfaceSerializer,
     NestedCableSerializer,
 )
 from dcim.api.serializers import (
     InterfaceConnectionSerializer,
-    ConnectedEndpointSerializer,
     IFACE_TYPE_CHOICES,
     IFACE_MODE_CHOICES,
 )
 from dcim.models import Interface
-from ipam.api.nested_serializers import NestedVLANSerializer
-from ipam.models import VLAN
+from ipam.api.nested_serializers import NestedPrefixSerializer
+from ipam.models import VLAN, Prefix
 from tenancy.api.nested_serializers import NestedTenantGroupSerializer
-from utilities.api import ChoiceField, ValidatedModelSerializer, SerializedPKRelatedField
+from utilities.api import ChoiceField, ValidatedModelSerializer, SerializedPKRelatedField, WritableNestedSerializer
 from tenancy.models import Tenant as Customer
+from utilities.utils import dynamic_import
+
+
+def get_serializer_for_model(model, prefix=''):
+    """
+    Dynamically resolve and return the appropriate serializer for a model.
+    """
+    app_name, model_name = model._meta.label.split('.')
+    serializer_name = '{}.api.serializers.{}{}Serializer'.format(
+        app_name, prefix, model_name
+    )
+
+    override_serializer_name = 'vapor.api.serializers.{}{}Serializer'.format(
+        prefix, model_name
+    )
+    try:
+        return dynamic_import(override_serializer_name)
+    except AttributeError:
+        pass
+
+    try:
+        return dynamic_import(serializer_name)
+    except AttributeError:
+        raise SerializerNotFound(
+            "Could not determine serializer for {}.{} with prefix '{}'".format(app_name, model_name, prefix)
+        )
+
+
+class NestedVLANSerializer(WritableNestedSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name='ipam-api:vlan-detail')
+
+    prefixes = SerializedPKRelatedField(
+        queryset=Prefix.objects.all(),
+        serializer=NestedPrefixSerializer,
+        required=False,
+        many=True,
+    )
+
+    class Meta:
+        model = VLAN
+        fields = ['id', 'url', 'vid', 'name', 'display_name', 'prefixes']
+
+
+class NestedInterfaceSerializer(WritableNestedSerializer):
+    device = NestedDeviceSerializer(read_only=True)
+    url = serializers.HyperlinkedIdentityField(view_name='dcim-api:interface-detail')
+    connection_status = ChoiceField(choices=CONNECTION_STATUS_CHOICES, read_only=True)
+    type = ChoiceField(choices=IFACE_TYPE_CHOICES, required=False)
+
+    untagged_vlan = NestedVLANSerializer(required=False, allow_null=True)
+    tagged_vlans = SerializedPKRelatedField(
+        queryset=VLAN.objects.all(),
+        serializer=NestedVLANSerializer,
+        required=False,
+        many=True,
+    )
+
+    class Meta:
+        model = Interface
+        fields = ['id', 'url', 'device', 'name', 'cable', 'connection_status', 'type', 'untagged_vlan', 'tagged_vlans']
+
+
+class ConnectedEndpointSerializer(ValidatedModelSerializer):
+    connected_endpoint_type = serializers.SerializerMethodField(read_only=True)
+    connected_endpoint = serializers.SerializerMethodField(read_only=True)
+    connection_status = ChoiceField(choices=CONNECTION_STATUS_CHOICES, read_only=True)
+
+    def get_connected_endpoint_type(self, obj):
+        if hasattr(obj, 'connected_endpoint') and obj.connected_endpoint is not None:
+            return '{}.{}'.format(
+                obj.connected_endpoint._meta.app_label,
+                obj.connected_endpoint._meta.model_name
+            )
+        return None
+
+    @swagger_serializer_method(serializer_or_field=serializers.DictField)
+    def get_connected_endpoint(self, obj):
+        """
+        Return the appropriate serializer for the type of connected object.
+        """
+        if getattr(obj, 'connected_endpoint', None) is None:
+            return None
+
+        serializer = get_serializer_for_model(obj.connected_endpoint, prefix='Nested')
+        context = {'request': self.context['request']}
+        data = serializer(obj.connected_endpoint, context=context).data
+
+        return data
 
 
 class CustomerSerializer(TaggitSerializer, CustomFieldModelSerializer):


### PR DESCRIPTION
 * Avoids modifications with upstream methods
 * Overrides VLAN, Interface, and ConnectedEndpoint serializers for Vapor specific needs

Example Response:

```json
{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 61,
            "device": {
                "id": 8,
                "url": "http://localhost:8000/api/dcim/devices/8/",
                "name": "Emulator C1 W2 L2B",
                "display_name": "Emulator C1 W2 L2B"
            },
            "name": "1-2",
            "type": {
                "value": 32766,
                "label": "Keystone"
            },
            "form_factor": {
                "value": 32766,
                "label": "Keystone"
            },
            "enabled": true,
            "lag": null,
            "mtu": null,
            "mac_address": null,
            "mgmt_only": false,
            "description": "",
            "connected_endpoint_type": "dcim.interface",
            "connected_endpoint": {
                "id": 482,
                "url": "http://localhost:8000/api/dcim/interfaces/482/",
                "device": {
                    "id": 49,
                    "url": "http://localhost:8000/api/dcim/devices/49/",
                    "name": "EFR1.TEST0.GCP",
                    "display_name": "EFR1.TEST0.GCP"
                },
                "name": "xe-0/0/1",
                "cable": 2,
                "connection_status": {
                    "value": true,
                    "label": "Connected"
                },
                "type": {
                    "value": 1200,
                    "label": "SFP+ (10GE)"
                },
                "untagged_vlan": null,
                "tagged_vlans": [
                    {
                        "id": 1,
                        "url": "http://localhost:8000/api/ipam/vlans/1/",
                        "vid": 2001,
                        "name": "VLAN 2001",
                        "display_name": "2001 (VLAN 2001)",
                        "prefixes": [
                            {
                                "id": 1,
                                "url": "http://localhost:8000/api/ipam/prefixes/1/",
                                "family": 4,
                                "prefix": "10.10.8.0/28"
                            }
                        ]
                    }
                ]
            },
            "connection_status": {
                "value": true,
                "label": "Connected"
            },
            "cable": {
                "id": 2,
                "url": "http://localhost:8000/api/dcim/cables/2/",
                "label": ""
            },
            "mode": null,
            "untagged_vlan": null,
            "tagged_vlans": [],
            "tags": [],
            "count_ipaddresses": 0
        },
        {
            "id": 62,
            "device": {
                "id": 8,
                "url": "http://localhost:8000/api/dcim/devices/8/",
                "name": "Emulator C1 W2 L2B",
                "display_name": "Emulator C1 W2 L2B"
            },
            "name": "3-4",
            "type": {
                "value": 32766,
                "label": "Keystone"
            },
            "form_factor": {
                "value": 32766,
                "label": "Keystone"
            },
            "enabled": true,
            "lag": null,
            "mtu": null,
            "mac_address": null,
            "mgmt_only": false,
            "description": "",
            "connected_endpoint_type": "dcim.interface",
            "connected_endpoint": {
                "id": 530,
                "url": "http://localhost:8000/api/dcim/interfaces/530/",
                "device": {
                    "id": 50,
                    "url": "http://localhost:8000/api/dcim/devices/50/",
                    "name": "EFR2.TEST0.GCP",
                    "display_name": "EFR2.TEST0.GCP"
                },
                "name": "xe-0/0/1",
                "cable": 3,
                "connection_status": {
                    "value": true,
                    "label": "Connected"
                },
                "type": {
                    "value": 1200,
                    "label": "SFP+ (10GE)"
                },
                "untagged_vlan": null,
                "tagged_vlans": [
                    {
                        "id": 1,
                        "url": "http://localhost:8000/api/ipam/vlans/1/",
                        "vid": 2001,
                        "name": "VLAN 2001",
                        "display_name": "2001 (VLAN 2001)",
                        "prefixes": [
                            {
                                "id": 1,
                                "url": "http://localhost:8000/api/ipam/prefixes/1/",
                                "family": 4,
                                "prefix": "10.10.8.0/28"
                            }
                        ]
                    }
                ]
            },
            "connection_status": {
                "value": true,
                "label": "Connected"
            },
            "cable": {
                "id": 3,
                "url": "http://localhost:8000/api/dcim/cables/3/",
                "label": ""
            },
            "mode": null,
            "untagged_vlan": null,
            "tagged_vlans": [],
            "tags": [],
            "count_ipaddresses": 0
        }
    ]
}
```

Tagged VLANs, and by association prefixes, will be on the connected_endpoint. We track VLANs on our switches not at the customer port. In this case `untagged_vlan` and `tagged_vlans` should be ignored on the parent record if the parent record is a customer network locker.