### PR TITLE
:hammer: Update initializers with most recent format

### DIFF
--- a/docker/initializers/devices.yml
+++ b/docker/initializers/devices.yml
@@ -2,483 +2,483 @@
   device_type: QFX5120-48Y-8C
   face: front
   name: EFR1.EMUL8R.000
-  site: Local Emulator
+  site: Local Emulator (EMUL8R.000)
 - device_role: Access Switch
   device_type: QFX5120-48Y-8C
   face: front
   name: EFR2.EMUL8R.000
-  site: Local Emulator
+  site: Local Emulator (EMUL8R.000)
 - custom_fields:
     sf_id: a6d8c2a0-b4cf-4940-a53f-e356354d78c9
   device_role: Customer Compute Locker
   device_type: 9U Locker
   face: front
-  name: Emulator C1 W1 L1A
+  name: L1-9A.R1.C1.EMUL8R.000
   position: 1
-  rack: Emulator C1 W1 Zone A
-  site: Local Emulator
+  rack: R1 Zone A
+  site: Local Emulator (EMUL8R.000)
   tenant: vaportest
 - custom_fields:
     sf_id: 6ba5ba20-5c2d-4210-adee-46e425756b43
   device_role: Customer Network Locker
   device_type: 9U Locker
   face: front
-  name: Emulator C1 W1 L1B
+  name: L1-9B.R1.C1.EMUL8R.000
   position: 1
-  rack: Emulator C1 W1 Zone B
-  site: Local Emulator
-- custom_fields:
-    sf_id: 910b806a-737e-409f-a54a-847acdfd3e83
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W1 L4A
-  position: 28
-  rack: Emulator C1 W1 Zone A
-  site: Local Emulator
-- custom_fields:
-    sf_id: 8a6824a0-dd8c-4b8a-a258-0127a9898ecf
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W1 L4B
-  position: 28
-  rack: Emulator C1 W1 Zone B
-  site: Local Emulator
-- custom_fields:
-    sf_id: c5fc8fa1-e713-411b-80e5-92f2fef62bdd
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W2 L1A
-  position: 1
-  rack: Emulator C1 W2 Zone A
-  site: Local Emulator
-- custom_fields:
-    sf_id: a9678550-58b4-41ed-8670-fce340145bc4
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W2 L1B
-  position: 1
-  rack: Emulator C1 W2 Zone B
-  site: Local Emulator
-- custom_fields:
-    sf_id: 32ec365c-ed18-4ac7-bc5e-ad7653b20863
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W2 L2A
-  position: 10
-  rack: Emulator C1 W2 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 36249382-fe42-4212-8497-de70422238f7
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W2 L2B
-  position: 10
-  rack: Emulator C1 W2 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: e95e48fd-790e-4033-9b4a-9a2b4d5b2588
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W2 L3A
-  position: 19
-  rack: Emulator C1 W2 Zone A
-  site: Local Emulator
-- custom_fields:
-    sf_id: b9f7b04c-fb2a-4549-b481-f47b7017fc84
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W2 L3B
-  position: 19
-  rack: Emulator C1 W2 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 136bcb0c-7177-4601-9f81-5df7fdce3829
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W2 L4A
-  position: 28
-  rack: Emulator C1 W2 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: e189281e-e2e7-49fd-a2a1-62f7082aca83
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W2 L4B
-  position: 28
-  rack: Emulator C1 W2 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: efafbd9e-6b48-429d-8d58-26b2fda96f58
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W3 L1A
-  position: 1
-  rack: Emulator C1 W3 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 3fda0ec6-4d06-4500-a9a7-4e5266b500e5
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W3 L1B
-  position: 1
-  rack: Emulator C1 W3 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: a29efaca-08c5-403e-a352-30237a675f1c
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W3 L2A
-  position: 10
-  rack: Emulator C1 W3 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 2ed96b2f-f1d5-4604-843d-32f0e98b65ca
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W3 L2B
-  position: 10
-  rack: Emulator C1 W3 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: f6f52fcf-9f42-4070-9062-3b1339d19841
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W3 L3A
-  position: 19
-  rack: Emulator C1 W3 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 7792510a-192a-4809-b982-2a852c57ddd1
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W3 L3B
-  position: 19
-  rack: Emulator C1 W3 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: d60d3b5e-62d4-496d-a02a-1dc6a70bd39b
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W3 L4A
-  position: 28
-  rack: Emulator C1 W3 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 6023f5dd-0bc1-4a16-987d-994141032a5e
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W3 L4B
-  position: 28
-  rack: Emulator C1 W3 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: ac7561d2-4c37-42c6-843b-749e8957c1e0
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W4 L1A
-  position: 1
-  rack: Emulator C1 W4 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 628de521-b70f-4597-8f54-a3d241d67c8a
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W4 L1B
-  position: 1
-  rack: Emulator C1 W4 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 16d10add-bcaa-4abd-b269-c73892567607
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W4 L2A
-  position: 10
-  rack: Emulator C1 W4 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 73243081-2e35-42be-b2a6-dcf664a7d4ba
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W4 L2B
-  position: 10
-  rack: Emulator C1 W4 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: d7b70ba7-0ef9-40da-a35e-be03e649706a
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W4 L3A
-  position: 19
-  rack: Emulator C1 W4 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 79fe0fd4-0f03-4f46-9b4a-a4634277fc2a
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W4 L3B
-  position: 19
-  rack: Emulator C1 W4 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: faf2e908-2b4b-4d87-9cbf-a8c7cae110fc
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W4 L4A
-  position: 28
-  rack: Emulator C1 W4 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: cc00b009-1d1f-40b1-99ea-f5ab1f155779
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W4 L4B
-  position: 28
-  rack: Emulator C1 W4 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: fb13c35a-1780-48d3-92da-ff66a9b9bf08
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W5 L1A
-  position: 1
-  rack: Emulator C1 W5 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: abd3767e-9a1b-4f34-8e4b-1255d0eef4d8
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W5 L1B
-  position: 1
-  rack: Emulator C1 W5 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: bda2f9d9-9364-42ba-974b-76f2fbf2ccd7
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W5 L2A
-  position: 10
-  rack: Emulator C1 W5 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 39740509-f89b-4c82-884e-ae1bb87c88f5
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W5 L2B
-  position: 10
-  rack: Emulator C1 W5 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 9eb87161-7df5-45d1-8ca0-356550f7f024
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W5 L3A
-  position: 19
-  rack: Emulator C1 W5 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: cf7d4e9d-6803-4587-8cd1-be27309d1414
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W5 L3B
-  position: 19
-  rack: Emulator C1 W5 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: b5103b46-4467-49c5-9b65-1a0285d41422
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W5 L4A
-  position: 28
-  rack: Emulator C1 W5 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: da922d8c-d491-4b15-a737-ad7649482188
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W5 L4B
-  position: 28
-  rack: Emulator C1 W5 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: d0c11e46-ace9-43d6-a545-ada55eb05b03
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W6 L1A
-  position: 1
-  rack: Emulator C1 W6 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 1bca6a2e-0810-404b-8eaa-f3ad12165894
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W6 L1B
-  position: 1
-  rack: Emulator C1 W6 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: ca2fd52a-053e-4883-aafa-a11e8da4c108
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W6 L2A
-  position: 10
-  rack: Emulator C1 W6 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: a5ef8dc0-01cf-4648-8cd3-3ba29c7d9eb9
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W6 L2B
-  position: 10
-  rack: Emulator C1 W6 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 3d3328fa-3853-4cf7-afff-2b174f5f1c60
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W6 L3A
-  position: 19
-  rack: Emulator C1 W6 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 52bba559-5fec-4640-af10-ce358240f1d2
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W6 L3B
-  position: 19
-  rack: Emulator C1 W6 Zone B
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 1536cf6e-991a-44c0-88f0-bdce489adb4c
-  device_role: Customer Compute Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W6 L4A
-  position: 28
-  rack: Emulator C1 W6 Zone A
-  site: Local Emulator
-  tenant: vaportest
-- custom_fields:
-    sf_id: 8d3cd060-ff10-4b97-b51c-4c524895aeb7
-  device_role: Customer Network Locker
-  device_type: 9U Locker
-  face: front
-  name: Emulator C1 W6 L4B
-  position: 28
-  rack: Emulator C1 W6 Zone B
-  site: Local Emulator
-  tenant: vaportest
+  rack: R1 Zone B
+  site: Local Emulator (EMUL8R.000)
 - custom_fields:
     sf_id: 34f87c0c-5009-4c3f-99aa-26a9ade66294
   device_role: Customer Compute Locker
   device_type: 9U Locker
   face: front
-  name: Emulator C1 W1 L2A
+  name: L10-18A.R1.C1.EMUL8R.000
   position: 10
-  rack: Emulator C1 W1 Zone A
-  site: Local Emulator
+  rack: R1 Zone A
+  site: Local Emulator (EMUL8R.000)
   tenant: VaporProvider
 - custom_fields:
     sf_id: 62d02859-b027-4cc8-afea-492e67525e49
   device_role: Customer Network Locker
   device_type: 9U Locker
   face: front
-  name: Emulator C1 W1 L2B
+  name: L10-18B.R1.C1.EMUL8R.000
   position: 10
-  rack: Emulator C1 W1 Zone B
-  site: Local Emulator
+  rack: R1 Zone B
+  site: Local Emulator (EMUL8R.000)
   tenant: VaporProvider
 - custom_fields:
     sf_id: 7ecacf66-0b0b-4bca-909f-92888560209a
   device_role: Customer Compute Locker
   device_type: 9U Locker
   face: front
-  name: Emulator C1 W1 L3A
+  name: L19-27A.R1.C1.EMUL8R.000
   position: 19
-  rack: Emulator C1 W1 Zone A
-  site: Local Emulator
+  rack: R1 Zone A
+  site: Local Emulator (EMUL8R.000)
   tenant: VaporProvider
 - custom_fields:
     sf_id: b9bf83a8-1ebf-45ce-8ffb-978870e32ddd
   device_role: Customer Network Locker
   device_type: 9U Locker
   face: front
-  name: Emulator C1 W1 L3B
+  name: L19-27B.R1.C1.EMUL8R.000
   position: 19
-  rack: Emulator C1 W1 Zone B
-  site: Local Emulator
+  rack: R1 Zone B
+  site: Local Emulator (EMUL8R.000)
   tenant: VaporProvider
+- custom_fields:
+    sf_id: 910b806a-737e-409f-a54a-847acdfd3e83
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36A.R1.C1.EMUL8R.000
+  position: 28
+  rack: R1 Zone A
+  site: Local Emulator (EMUL8R.000)
+- custom_fields:
+    sf_id: 8a6824a0-dd8c-4b8a-a258-0127a9898ecf
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36B.R1.C1.EMUL8R.000
+  position: 28
+  rack: R1 Zone B
+  site: Local Emulator (EMUL8R.000)
+- custom_fields:
+    sf_id: c5fc8fa1-e713-411b-80e5-92f2fef62bdd
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9A.R2.C1.EMUL8R.000
+  position: 1
+  rack: R2 Zone A
+  site: Local Emulator (EMUL8R.000)
+- custom_fields:
+    sf_id: a9678550-58b4-41ed-8670-fce340145bc4
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9B.R2.C1.EMUL8R.000
+  position: 1
+  rack: R2 Zone B
+  site: Local Emulator (EMUL8R.000)
+- custom_fields:
+    sf_id: 32ec365c-ed18-4ac7-bc5e-ad7653b20863
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18A.R2.C1.EMUL8R.000
+  position: 10
+  rack: R2 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 36249382-fe42-4212-8497-de70422238f7
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18B.R2.C1.EMUL8R.000
+  position: 10
+  rack: R2 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: e95e48fd-790e-4033-9b4a-9a2b4d5b2588
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27A.R2.C1.EMUL8R.000
+  position: 19
+  rack: R2 Zone A
+  site: Local Emulator (EMUL8R.000)
+- custom_fields:
+    sf_id: b9f7b04c-fb2a-4549-b481-f47b7017fc84
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27B.R2.C1.EMUL8R.000
+  position: 19
+  rack: R2 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 136bcb0c-7177-4601-9f81-5df7fdce3829
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36A.R2.C1.EMUL8R.000
+  position: 28
+  rack: R2 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: e189281e-e2e7-49fd-a2a1-62f7082aca83
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36B.R2.C1.EMUL8R.000
+  position: 28
+  rack: R2 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: efafbd9e-6b48-429d-8d58-26b2fda96f58
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9A.R3.C1.EMUL8R.000
+  position: 1
+  rack: R3 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 3fda0ec6-4d06-4500-a9a7-4e5266b500e5
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9B.R3.C1.EMUL8R.000
+  position: 1
+  rack: R3 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: a29efaca-08c5-403e-a352-30237a675f1c
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18A.R3.C1.EMUL8R.000
+  position: 10
+  rack: R3 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 2ed96b2f-f1d5-4604-843d-32f0e98b65ca
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18B.R3.C1.EMUL8R.000
+  position: 10
+  rack: R3 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: f6f52fcf-9f42-4070-9062-3b1339d19841
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27A.R3.C1.EMUL8R.000
+  position: 19
+  rack: R3 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 7792510a-192a-4809-b982-2a852c57ddd1
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27B.R3.C1.EMUL8R.000
+  position: 19
+  rack: R3 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: d60d3b5e-62d4-496d-a02a-1dc6a70bd39b
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36A.R3.C1.EMUL8R.000
+  position: 28
+  rack: R3 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 6023f5dd-0bc1-4a16-987d-994141032a5e
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36B.R3.C1.EMUL8R.000
+  position: 28
+  rack: R3 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: ac7561d2-4c37-42c6-843b-749e8957c1e0
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9A.R4.C1.EMUL8R.000
+  position: 1
+  rack: R4 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 628de521-b70f-4597-8f54-a3d241d67c8a
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9B.R4.C1.EMUL8R.000
+  position: 1
+  rack: R4 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 16d10add-bcaa-4abd-b269-c73892567607
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18A.R4.C1.EMUL8R.000
+  position: 10
+  rack: R4 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 73243081-2e35-42be-b2a6-dcf664a7d4ba
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18B.R4.C1.EMUL8R.000
+  position: 10
+  rack: R4 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: d7b70ba7-0ef9-40da-a35e-be03e649706a
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27A.R4.C1.EMUL8R.000
+  position: 19
+  rack: R4 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 79fe0fd4-0f03-4f46-9b4a-a4634277fc2a
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27B.R4.C1.EMUL8R.000
+  position: 19
+  rack: R4 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: faf2e908-2b4b-4d87-9cbf-a8c7cae110fc
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36A.R4.C1.EMUL8R.000
+  position: 28
+  rack: R4 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: cc00b009-1d1f-40b1-99ea-f5ab1f155779
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36B.R4.C1.EMUL8R.000
+  position: 28
+  rack: R4 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: fb13c35a-1780-48d3-92da-ff66a9b9bf08
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9A.R5.C1.EMUL8R.000
+  position: 1
+  rack: R5 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: abd3767e-9a1b-4f34-8e4b-1255d0eef4d8
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9B.R5.C1.EMUL8R.000
+  position: 1
+  rack: R5 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: bda2f9d9-9364-42ba-974b-76f2fbf2ccd7
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18A.R5.C1.EMUL8R.000
+  position: 10
+  rack: R5 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 39740509-f89b-4c82-884e-ae1bb87c88f5
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18B.R5.C1.EMUL8R.000
+  position: 10
+  rack: R5 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 9eb87161-7df5-45d1-8ca0-356550f7f024
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27A.R5.C1.EMUL8R.000
+  position: 19
+  rack: R5 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: cf7d4e9d-6803-4587-8cd1-be27309d1414
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27B.R5.C1.EMUL8R.000
+  position: 19
+  rack: R5 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: b5103b46-4467-49c5-9b65-1a0285d41422
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36A.R5.C1.EMUL8R.000
+  position: 28
+  rack: R5 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: da922d8c-d491-4b15-a737-ad7649482188
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36B.R5.C1.EMUL8R.000
+  position: 28
+  rack: R5 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: d0c11e46-ace9-43d6-a545-ada55eb05b03
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9A.R6.C1.EMUL8R.000
+  position: 1
+  rack: R6 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 1bca6a2e-0810-404b-8eaa-f3ad12165894
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L1-9B.R6.C1.EMUL8R.000
+  position: 1
+  rack: R6 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: ca2fd52a-053e-4883-aafa-a11e8da4c108
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18A.R6.C1.EMUL8R.000
+  position: 10
+  rack: R6 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: a5ef8dc0-01cf-4648-8cd3-3ba29c7d9eb9
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L10-18B.R6.C1.EMUL8R.000
+  position: 10
+  rack: R6 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 3d3328fa-3853-4cf7-afff-2b174f5f1c60
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27A.R6.C1.EMUL8R.000
+  position: 19
+  rack: R6 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 52bba559-5fec-4640-af10-ce358240f1d2
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L19-27B.R6.C1.EMUL8R.000
+  position: 19
+  rack: R6 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 1536cf6e-991a-44c0-88f0-bdce489adb4c
+  device_role: Customer Compute Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36A.R6.C1.EMUL8R.000
+  position: 28
+  rack: R6 Zone A
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest
+- custom_fields:
+    sf_id: 8d3cd060-ff10-4b97-b51c-4c524895aeb7
+  device_role: Customer Network Locker
+  device_type: 9U Locker
+  face: front
+  name: L28-36B.R6.C1.EMUL8R.000
+  position: 28
+  rack: R6 Zone B
+  site: Local Emulator (EMUL8R.000)
+  tenant: vaportest

--- a/docker/initializers/rack_groups.yml
+++ b/docker/initializers/rack_groups.yml
@@ -1,18 +1,18 @@
-- name: Emulator C1 W1
-  site: Local Emulator
-  slug: w1-c1-emul8r-000
-- name: Emulator C1 W2
-  site: Local Emulator
-  slug: w2-c1-emul8r-000
-- name: Emulator C1 W3
-  site: Local Emulator
-  slug: w3-c1-emul8r-000
-- name: Emulator C1 W4
-  site: Local Emulator
-  slug: w4-c1-emul8r-000
-- name: Emulator C1 W5
-  site: Local Emulator
-  slug: w5-c1-emul8r-000
-- name: Emulator C1 W6
-  site: Local Emulator
-  slug: w6-c1-emul8r-000
+- name: Emulator C1 R1
+  site: Local Emulator (EMUL8R.000)
+  slug: r1-c1-emul8r-000
+- name: Emulator C1 R2
+  site: Local Emulator (EMUL8R.000)
+  slug: r2-c1-emul8r-000
+- name: Emulator C1 R3
+  site: Local Emulator (EMUL8R.000)
+  slug: r3-c1-emul8r-000
+- name: Emulator C1 R4
+  site: Local Emulator (EMUL8R.000)
+  slug: r4-c1-emul8r-000
+- name: Emulator C1 R5
+  site: Local Emulator (EMUL8R.000)
+  slug: r5-c1-emul8r-000
+- name: Emulator C1 R6
+  site: Local Emulator (EMUL8R.000)
+  slug: r6-c1-emul8r-000

--- a/docker/initializers/racks.yml
+++ b/docker/initializers/racks.yml
@@ -1,144 +1,144 @@
-- facility_id: a.w1.c1.emul8r.000
-  group: Emulator C1 W1
-  name: Emulator C1 W1 Zone A
+- facility_id: a.r1.c1.emul8r.000
+  group: Emulator C1 R1
+  name: R1 Zone A
   role: Customer
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: b.w1.c1.emul8r.000
-  group: Emulator C1 W1
-  name: Emulator C1 W1 Zone B
+- facility_id: b.r1.c1.emul8r.000
+  group: Emulator C1 R1
+  name: R1 Zone B
   role: Utility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: f.w1.c1.emul8r.000
-  group: Emulator C1 W1
-  name: Emulator C1 W1 Facility
+- facility_id: f.r1.c1.emul8r.000
+  group: Emulator C1 R1
+  name: R1 Facility
   role: Facility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: a.w2.c1.emul8r.000
-  group: Emulator C1 W2
-  name: Emulator C1 W2 Zone A
+- facility_id: a.r2.c1.emul8r.000
+  group: Emulator C1 R2
+  name: R2 Zone A
   role: Customer
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: b.w2.c1.emul8r.000
-  group: Emulator C1 W2
-  name: Emulator C1 W2 Zone B
+- facility_id: b.r2.c1.emul8r.000
+  group: Emulator C1 R2
+  name: R2 Zone B
   role: Utility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: f.w2.c1.emul8r.000
-  group: Emulator C1 W2
-  name: Emulator C1 W2 Facility
+- facility_id: f.r2.c1.emul8r.000
+  group: Emulator C1 R2
+  name: R2 Facility
   role: Facility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: a.w3.c1.emul8r.000
-  group: Emulator C1 W3
-  name: Emulator C1 W3 Zone A
+- facility_id: a.r3.c1.emul8r.000
+  group: Emulator C1 R3
+  name: R3 Zone A
   role: Customer
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: b.w3.c1.emul8r.000
-  group: Emulator C1 W3
-  name: Emulator C1 W3 Zone B
+- facility_id: b.r3.c1.emul8r.000
+  group: Emulator C1 R3
+  name: R3 Zone B
   role: Utility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: f.w3.c1.emul8r.000
-  group: Emulator C1 W3
-  name: Emulator C1 W3 Facility
+- facility_id: f.r3.c1.emul8r.000
+  group: Emulator C1 R3
+  name: R3 Facility
   role: Facility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: a.w4.c1.emul8r.000
-  group: Emulator C1 W4
-  name: Emulator C1 W4 Zone A
+- facility_id: a.r4.c1.emul8r.000
+  group: Emulator C1 R4
+  name: R4 Zone A
   role: Customer
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: b.w4.c1.emul8r.000
-  group: Emulator C1 W4
-  name: Emulator C1 W4 Zone B
+- facility_id: b.r4.c1.emul8r.000
+  group: Emulator C1 R4
+  name: R4 Zone B
   role: Utility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: f.w4.c1.emul8r.000
-  group: Emulator C1 W4
-  name: Emulator C1 W4 Facility
+- facility_id: f.r4.c1.emul8r.000
+  group: Emulator C1 R4
+  name: R4 Facility
   role: Facility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: a.w5.c1.emul8r.000
-  group: Emulator C1 W5
-  name: Emulator C1 W5 Zone A
+- facility_id: a.r5.c1.emul8r.000
+  group: Emulator C1 R5
+  name: R5 Zone A
   role: Customer
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: b.w5.c1.emul8r.000
-  group: Emulator C1 W5
-  name: Emulator C1 W5 Zone B
+- facility_id: b.r5.c1.emul8r.000
+  group: Emulator C1 R5
+  name: R5 Zone B
   role: Utility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: f.w5.c1.emul8r.000
-  group: Emulator C1 W5
-  name: Emulator C1 W5 Facility
+- facility_id: f.r5.c1.emul8r.000
+  group: Emulator C1 R5
+  name: R5 Facility
   role: Facility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: a.w6.c1.emul8r.000
-  group: Emulator C1 W6
-  name: Emulator C1 W6 Zone A
+- facility_id: a.r6.c1.emul8r.000
+  group: Emulator C1 R6
+  name: R6 Zone A
   role: Customer
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: b.w6.c1.emul8r.000
-  group: Emulator C1 W6
-  name: Emulator C1 W6 Zone B
+- facility_id: b.r6.c1.emul8r.000
+  group: Emulator C1 R6
+  name: R6 Zone B
   role: Utility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'
-- facility_id: f.w6.c1.emul8r.000
-  group: Emulator C1 W6
-  name: Emulator C1 W6 Facility
+- facility_id: f.r6.c1.emul8r.000
+  group: Emulator C1 R6
+  name: R6 Facility
   role: Facility
-  site: Local Emulator
-  type: 4-post cabinet
+  site: Local Emulator (EMUL8R.000)
+  type: 4-post-cabinet
   u_height: '36'
   width: '19'

--- a/docker/initializers/regions.yml
+++ b/docker/initializers/regions.yml
@@ -1,2 +1,2 @@
-- name: GCP
+- name: GCP (GCP)
   slug: gcp

--- a/docker/initializers/sites.yml
+++ b/docker/initializers/sites.yml
@@ -1,20 +1,28 @@
 
-- name: Local Emulator
+- name: Local Emulator (EMUL8R.000)
   slug: EMUL8R-000
+  region: GCP (GCP)
+  status: active
   custom_fields:
     sf_id: 51f4ca13-2658-4169-8a06-51f87d62b16f
 
 - name: Future Pending Site
   slug: FUT-000
+  region: GCP (GCP)
+  status: active
   custom_fields:
     sf_id: 73727fc7-138b-4cbe-a184-311500cb3992
 
 - name: Virtual VEM-150
   slug: virt-01
+  region: GCP (GCP)
+  status: active
   custom_fields:
     sf_id: 5b385220-c9d6-11e9-a32f-2a2ae2dbcce4
 
 - name: Cloud Virtual Chamber
   slug: cloud-virtual-chamber
+  status: active
+  region: GCP (GCP)
   custom_fields:
     sf_id: 2e3b4b3d-111e-41f8-aef8-8ebdf19dfbf8

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,4 @@ Pillow==7.1.1
 psycopg2-binary==2.8.5
 pycryptodome==3.9.7
 PyYAML==5.3.1
-redis==3.4.1
 svgwrite==1.4


### PR DESCRIPTION
Updates the initializers to be in sync with what's used in Dev & Preview deployments.
Adds fix for racks (`type: 4-post-cabinet`)
Adds fix for sites (`status: active`)

Jenkins is failing with the `hset() mapping` error that is resolved by the workaround in https://github.com/vapor-ware/netbox/pull/37