### PR TITLE
:pushpin: Remove pin for redis to enable startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,4 @@ Pillow==7.1.1
 psycopg2-binary==2.8.5
 pycryptodome==3.9.7
 PyYAML==5.3.1
-redis==3.4.1
 svgwrite==1.4


### PR DESCRIPTION
This small change is the official workaround for an error that prevents netbox startup.
An official upstream fix is in place, but this change is required if you want to do anything with this repo currently.
Here is the upstream issue and explanation: https://github.com/netbox-community/netbox/issues/4910

**My thoughts on how to handle this are to merge in the workaround, so the repo is functional, and open an issue to remove the workaround before next upstream sync. Other thoughts on how to handle this are appreciated. 
