### PR TITLE
:arrow_up: Bump netbox virtual circuit plugin to version 1.0.0

### DIFF
--- a/requirements.extras.txt
+++ b/requirements.extras.txt
@@ -1,2 +1,2 @@
 django-allauth==0.42.0
-netbox-virtual-circuit-plugin==0.3.0
+netbox-virtual-circuit-plugin==1.0.0


### PR DESCRIPTION
[v1.0.0 (2020-08-21)](https://github.com/vapor-ware/netbox-virtual-circuit-plugin/blob/master/CHANGELOG.md#v100-2020-08-21)