### PR TITLE
vlan response status field addition

### DIFF
--- a/netbox/vapor/api/serializers.py
+++ b/netbox/vapor/api/serializers.py
@@ -57,7 +57,7 @@ class NestedVaporVLANSerializer(WritableNestedSerializer):
 
     class Meta:
         model = VLAN
-        fields = ['id', 'url', 'vid', 'name', 'display_name', 'prefixes']
+        fields = ['id', 'url', 'vid', 'name', 'display_name', 'prefixes', 'status']
 
 
 class NestedVLANInterfaceSerializer(WritableNestedSerializer):


### PR DESCRIPTION
This PR will add status field in Vlan response when calling vapor interface end point which will help to extract status of vlan in the issue https://github.com/vapor-ware/network-api/issues/97.