### PR TITLE
add 000 region to solve mock data issue in integration test

### DIFF
--- a/docker/initializers/regions.yml
+++ b/docker/initializers/regions.yml
@@ -1,2 +1,4 @@
 - name: GCP (GCP)
   slug: gcp
+- name: 000 (000)
+  slug: '000'

--- a/docker/initializers/sites.yml
+++ b/docker/initializers/sites.yml
@@ -1,7 +1,7 @@
 
 - name: Local Emulator (EMUL8R.000)
   slug: EMUL8R-000
-  region: GCP (GCP)
+  region: 000 (000)
   status: active
   custom_fields:
     sf_id: 51f4ca13-2658-4169-8a06-51f87d62b16f


### PR DESCRIPTION
This will add 000 as region to solve the mock data issue in network-api while doing integration tests.
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: 
[#136](https://github.com/vapor-ware/network-api/issues/136)

<ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
