### PR TITLE
🚑 Hotfix ci config.

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -57,13 +57,6 @@ spec:
     args:
     - --appendonly yes
     - --requirepass netbox
-  nodeSelector:
-    cloud.google.com/gke-nodepool: jenkins
-  tolerations:
-  - key: role
-    operator: Equal
-    value: jenkins
-    effect: NoSchedule
 """
         }
       }


### PR DESCRIPTION
Jenkins nodeselecter is suspending the jobs indefenitely. This will get
the pipeline rolling again.
